### PR TITLE
Add Testee and steal-tools to npmIgnore

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   "system": {
     "ignoreBrowser": true,
     "npmIgnore": [
-      "documentjs"
+      "documentjs",
+      "testee",
+      "steal-tools"
     ],
     "npmDependencies": [
       "steal-qunit"


### PR DESCRIPTION
Bufferutils (a dependency of one of the server packages) is not being built in Node 4.0 so Steal breaks trying to load its `package.json`. They should be ignored anyway.
