### PR TITLE
Add can-plugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "keywords": [
     "Interrupt",
     "plugin",
-    "canjs"
+    "canjs",
+    "can-plugin"
   ],
   "author": "Bitovi",
   "license": "MIT",


### PR DESCRIPTION
This adds the keyword "can-plugin".  This helps with a tool I'm working
on that categories CanJS plugins like components, attributes, and
regular plugins. Please merge! @joe-crick 
